### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2.1 (unreleased)
+3.0 (unreleased)
 ----------------
 
 - Add support for Python 3.12, 3.13.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 3.0 (unreleased)
 ----------------
 
+- Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace. Caution: This change requires to switch all packages in the namespace of the package to versions using a PEP 420 namespace.
+
 - Add support for Python 3.12, 3.13.
 
 - Drop support for Python 3.7, 3.8.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = '2.1.dev0'
+version = '3.0.dev0'
 
 
 def read(path):

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -37,9 +36,6 @@ setup(name="z3c.zcmlhook",
       author_email="zope-dev@zope.dev",
       url="https://github.com/zopefoundation/z3c.zcmlhook",
       license="ZPL",
-      namespace_packages=["z3c"],
-      packages=find_packages("src"),
-      package_dir={"": "src"},
       include_package_data=True,
       zip_safe=False,
       python_requires='>=3.9',

--- a/src/z3c/__init__.py
+++ b/src/z3c/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace. Caution: This change requires to switch all packages in the namespace of the package to versions using a PEP 420 namespace.**
- **Switch to PEP 420 native namespace.**
